### PR TITLE
Fix compatibility issues with wis2box

### DIFF
--- a/docker/wait-for-elasticsearch.sh
+++ b/docker/wait-for-elasticsearch.sh
@@ -34,12 +34,12 @@ until $(curl --output /dev/null --silent --head --fail "$host")  ; do
 done
 
 # First wait for ES to start...
-response=$(curl $host)
+response=$(curl --write-out %{http_code} --silent --output /dev/null "$host")
 
 until [ "$response" = "200" ]  ; do
     response=$(curl --write-out %{http_code} --silent --output /dev/null "$host")
     >&2 echo "Elasticsearch is up but unavailable - No Response - sleeping"
-    sleep 10
+    sleep 5
 
 done
 


### PR DESCRIPTION
- Derive `PYGEOAPI_CONFIG` name from wis2box variables.
- Lock all python files and reload on modifications to `PYGEOAPI_CONFIG` for hot reload. No need to restart this container when changes are made to the configuration file.
- Extract response code for the first pass on Elasticsearch health check. Reduce checks thereafter to 5 seconds.