### PR TITLE
wis2box 1.0b5 wsi-fix

### DIFF
--- a/wis2box_api/plugins/process/oscar2feature.py
+++ b/wis2box_api/plugins/process/oscar2feature.py
@@ -170,7 +170,7 @@ class Oscar2FeatureProcessor(BaseProcessor):
             },
             'properties': {
                 'name': station.get('station_name', ''),
-                'wigos_station_identifier': station.get('wigos_station_identifier', ''), # noqa
+                'wigos_station_identifier': wsi,
                 'traditional_station_identifier': tsi,
                 'facility_type': station.get('facility_type', ''),
                 'territory_name': territory_name,


### PR DESCRIPTION
While working with Brazil I noted that they used secondary primary IDs from their stations in OSCAR. In order to create a working station-list for their data this secondary wsi needs to be inserted in their station-metadata, requiring this minor fix.