### PR TITLE
don't check if metadata exist

### DIFF
--- a/wis2box_api/plugins/process/publish_dataset.py
+++ b/wis2box_api/plugins/process/publish_dataset.py
@@ -219,15 +219,15 @@ class PublishDatasetProcessor(BaseProcessor):
             status = f'Error publishing on topic={topic}, error={e}'
         # sleep for a 1 second to allow the backend to process the message
         time.sleep(1)
-        metadata_id = metadata['id'] if 'id' in metadata else 'unknown'
+        #metadata_id = metadata['id'] if 'id' in metadata else 'unknown'
         # check that discovery-api/metadata/items/{metadata_id} exists
-        url = f'{WIS2BOX_DOCKER_API_URL}/collections/discovery-metadata/items/{metadata_id}?f=json' # noqa
-        response = requests.get(url)
+        #url = f'{WIS2BOX_DOCKER_API_URL}/collections/discovery-metadata/items/{metadata_id}?f=json' # noqa
+        #response = requests.get(url)
         # when the collection does not exists the api returns a 404
-        if response.status_code != 200:
-            status = f'Status: {response.status_code}. Failed to create metadata with id={metadata_id}' # noqa
-        else:
-            status = 'success'
+        #if response.status_code != 200:
+        #    status = f'Status: {response.status_code}. Failed to create metadata with id={metadata_id}' # noqa
+        #else:
+        #    status = 'success'
 
         try:
             # send a message to refresh the data mappings

--- a/wis2box_api/plugins/process/publish_dataset.py
+++ b/wis2box_api/plugins/process/publish_dataset.py
@@ -21,7 +21,6 @@
 
 import json
 import logging
-import requests
 import time
 
 import paho.mqtt.publish as publish
@@ -32,7 +31,6 @@ from wis2box_api.wis2box.env import BROKER_HOST
 from wis2box_api.wis2box.env import BROKER_PORT
 from wis2box_api.wis2box.env import BROKER_USERNAME
 from wis2box_api.wis2box.env import BROKER_PASSWORD
-from wis2box_api.wis2box.env import WIS2BOX_DOCKER_API_URL
 
 
 LOGGER = logging.getLogger(__name__)
@@ -219,15 +217,6 @@ class PublishDatasetProcessor(BaseProcessor):
             status = f'Error publishing on topic={topic}, error={e}'
         # sleep for a 1 second to allow the backend to process the message
         time.sleep(1)
-        #metadata_id = metadata['id'] if 'id' in metadata else 'unknown'
-        # check that discovery-api/metadata/items/{metadata_id} exists
-        #url = f'{WIS2BOX_DOCKER_API_URL}/collections/discovery-metadata/items/{metadata_id}?f=json' # noqa
-        #response = requests.get(url)
-        # when the collection does not exists the api returns a 404
-        #if response.status_code != 200:
-        #    status = f'Status: {response.status_code}. Failed to create metadata with id={metadata_id}' # noqa
-        #else:
-        #    status = 'success'
 
         try:
             # send a message to refresh the data mappings


### PR DESCRIPTION
This will avoid the wis2box-webapp displaying:
 
![image](https://github.com/user-attachments/assets/de780d5e-867a-4c62-a9e2-dff699f8594a)
