### PR TITLE
update properties.language to an object per latest OARec changes

### DIFF
--- a/wis2box_api/plugins/process/publish_dataset.py
+++ b/wis2box_api/plugins/process/publish_dataset.py
@@ -122,7 +122,9 @@ PROCESS_METADATA = {
                     "identifier": "urn:wmo:md:test-wis-node2:surface-based-observations.synop", # noqa
                     "title": "Hourly synoptic observations from fixed-land stations (SYNOP) (test-wis-node2)", # noqa
                     "description": "this is a test dataset",
-                    "language": None,
+                    "language": {
+                        "code": None
+                    },
                     "keywords": ["surface", "land", "observations"],
                     "themes": [{
                         "concepts": [{"id": "weather", "title": "Weather"}],


### PR DESCRIPTION
Update WCMP2 language to be an object (not a string) per latest OGC API - Records updates.