### PR TITLE
processes: set jobControlOptions for pygeoapi compat

### DIFF
--- a/wis2box_api/plugins/process/bufr2UpperAirChart.py
+++ b/wis2box_api/plugins/process/bufr2UpperAirChart.py
@@ -54,6 +54,7 @@ PROCESS_METADATA = {
     'description': 'Download bufr from URL and create Temperature Log-P chart',  # noqa
     'keywords': [],
     'links': [],
+    'jobControlOptions': ['sync-execute', 'async-execute'],
     'inputs': {
         'data_url': {
             'title': 'data_url',

--- a/wis2box_api/plugins/process/dataset_info.py
+++ b/wis2box_api/plugins/process/dataset_info.py
@@ -56,6 +56,7 @@ PROCESS_DEF = {
     'description': 'Retrieve information about datasets contained in the WIS2BOX', # noqa
     'keywords': [],
     'links': [],
+    'jobControlOptions': ['sync-execute', 'async-execute'],
     'inputs': {
         'collection': {
             'title': {'en': 'Collection identifier'},

--- a/wis2box_api/plugins/process/mappings_info.py
+++ b/wis2box_api/plugins/process/mappings_info.py
@@ -38,6 +38,7 @@ PROCESS_DEF = {
     },
     'keywords': [],
     'links': [],
+    'jobControlOptions': ['sync-execute', 'async-execute'],
     'inputs': {
         'plugin': {
             'title': 'Plugin',

--- a/wis2box_api/plugins/process/oscar2feature.py
+++ b/wis2box_api/plugins/process/oscar2feature.py
@@ -34,6 +34,7 @@ PROCESS_METADATA = {
     'description': 'Query OSCAR and return station metadata for wis2box',
     'keywords': [],
     'links': [],
+    'jobControlOptions': ['sync-execute', 'async-execute'],
     'inputs': {
         'wigos_station_identifier': {
             'title': {'en': 'WIGOS Station Identifier'},

--- a/wis2box_api/plugins/process/publish_dataset.py
+++ b/wis2box_api/plugins/process/publish_dataset.py
@@ -42,6 +42,7 @@ PROCESS_METADATA = {
     'description': 'Update metadata and data-mappings in backend and publish metadata-notification', # noqa
     'keywords': [],
     'links': [],
+    'jobControlOptions': ['sync-execute', 'async-execute'],
     'inputs': {
         'metadata': {
             'title': {'en': 'metadata'},

--- a/wis2box_api/plugins/process/station_info.py
+++ b/wis2box_api/plugins/process/station_info.py
@@ -40,6 +40,7 @@ PROCESS_DEF = {
     ' counted observations by station',
     'keywords': [],
     'links': [],
+    'jobControlOptions': ['sync-execute', 'async-execute'],
     'inputs': {
         'collection': {
             'title': {'en': 'Collection identifier'},

--- a/wis2box_api/plugins/process/station_msg_info.py
+++ b/wis2box_api/plugins/process/station_msg_info.py
@@ -40,6 +40,7 @@ PROCESS_DEF = {
     ' counted messages by station',
     'keywords': [],
     'links': [],
+    'jobControlOptions': ['sync-execute', 'async-execute'],
     'inputs': {
         'collection': {
             'title': {'en': 'Collection identifier'},

--- a/wis2box_api/plugins/process/storage_event.py
+++ b/wis2box_api/plugins/process/storage_event.py
@@ -40,6 +40,7 @@ PROCESS_METADATA = {
     'description': 'POST a storage-event', # noqa
     'keywords': [],
     'links': [],
+    'jobControlOptions': ['sync-execute', 'async-execute'],
     'inputs': {
         'storage_event': {
             'title': {'en': 'Storage Event'},

--- a/wis2box_api/plugins/process/unpublish_dataset.py
+++ b/wis2box_api/plugins/process/unpublish_dataset.py
@@ -43,6 +43,7 @@ PROCESS_METADATA = {
     'description': 'Remove metadata and data-mappings in backend and send notification to unpublish metadata', # noqa
     'keywords': [],
     'links': [],
+    'jobControlOptions': ['sync-execute', 'async-execute'],
     'inputs': {
         'metadata_id': {
             'title': {'en': 'metadata record identifier'},


### PR DESCRIPTION
pygeoapi 0.23 derives process jobControlOptions declarations directly from the process metadata definition.  This PR explicitly declares sync and async support for wis2box processes that do not have jobControlOptions already defined.  The effective change is how Swagger renders the OpenAPI definition in order to populate the Prefer header option.