### PR TITLE
synop2bufr update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ json-merge-patch
 paho-mqtt
 pygeometa
 pymetdecoder-wmo==0.1.14
-synop2bufr==0.8.0
+synop2bufr==0.8.1
 csv2bufr==0.8.8
 minio==7.2.7
 bufr2geojson==0.7.1


### PR DESCRIPTION
Update synop2bufr to add a protection against none in past weather to prevent the error:
```2026-05-26 07:23:21 [ERROR] Error parsing SYNOP report: AAXX 17181 15480 05997 41901 10114 20089 30035 40052 51009 60002 7000/ 80005 222// 06074 2//// 333 10150 20084 31015 4/000 55300 10188 20000 30000 60007 91004 91106 92427. 'NoneType' object is not subscriptable!```

https://github.com/World-Meteorological-Organization/synop2bufr/pull/59

